### PR TITLE
fix: assign NCF to Sales Invoices with is_pos=True

### DIFF
--- a/dgii_compliance/dgii_compliance/add_ncf_data.py
+++ b/dgii_compliance/dgii_compliance/add_ncf_data.py
@@ -12,10 +12,12 @@ def main(doc,method):
 	Args:
 	doc: Sales Invoice document to process
 	"""
-	if doc.is_pos and doc.doctype == 'Sales Invoice': #si la factura viene del POS no aplica para dgii, hay que aplicar los ncf a las factura pos individuales
+	if doc.is_pos and doc.is_consolidated and doc.doctype == 'Sales Invoice': #si la factura viene del cierre de sesión POS no aplica para dgii, hay que aplicar los ncf a las factura pos individuales
 		doc.custom_factura_de_valor_fiscal = 0
-		#Sales Invoices generated at POS Closing seem to inherite the value of fields, so ncf was getting fille
-		#when it shouldn't, this make sures is empty as this could cause confusion fo accounting
+		#Sales Invoices generated at POS Closing seem to inherit the value of fields, so ncf was getting filled
+		#when it shouldn't. This makes sure it's empty as this could cause confusion for accounting.
+		#Note: is_consolidated distinguishes POS-closing batch invoices from regular Sales Invoices where
+		#the user simply checked is_pos to record an immediate payment (those should still get an NCF).
 		doc.custom_ncf = None
 		doc.custom_ncf_vencimiento = None
 		return


### PR DESCRIPTION
## Summary

Fixes #11

Sales Invoices where the user checks `is_pos` to record an immediate payment (no separate Payment Entry needed) were incorrectly being excluded from NCF assignment. The app was unchecking `custom_factura_de_valor_fiscal` and clearing the NCF fields before returning early.

## Root Cause

The guard condition in `add_ncf_data.main()` only checked `is_pos`, but that flag is shared by two very different cases:

| Case | `is_pos` | `is_consolidated` | Should get NCF? |
|---|---|---|---|
| POS session-closing batch invoice | ✅ | ✅ | ❌ NCF goes on individual POS Invoices |
| Regular Sales Invoice with immediate payment | ✅ | ❌ | ✅ Valid fiscal document |

## Change

```python
# Before
if doc.is_pos and doc.doctype == 'Sales Invoice':

# After
if doc.is_pos and doc.is_consolidated and doc.doctype == 'Sales Invoice':
```

Adding `is_consolidated` narrows the skip to POS-closing batch invoices only. Regular Sales Invoices with `is_pos=True` now flow through the normal NCF assignment logic.